### PR TITLE
Curl::setCurlOption should return the object instead of void.

### DIFF
--- a/src/Curl.php
+++ b/src/Curl.php
@@ -201,10 +201,11 @@ class Curl implements ClientInterface
     /**
      * @param string $option
      * @param mixed $value
-     * @return void
+     * @return Curl
      */
-    public function setCurlOption($option, $value)
+    public function setCurlOption($option, $value): Curl
     {
         curl_setopt($this->curlHandler, $option, $value);
+        return $this;
     }
 }


### PR DESCRIPTION
Curl::setCurlOption should return the object to allow for method chaining. This won't break backwards compatibility because previously there was no return.